### PR TITLE
✨feature: adds the class 04 - stemming and lemmatization

### DIFF
--- a/01_basic_nlp_course/04_stemming_lemmatization.ipynb
+++ b/01_basic_nlp_course/04_stemming_lemmatization.ipynb
@@ -1,0 +1,211 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3c552918",
+   "metadata": {},
+   "source": [
+    "# Basic NLP Course\n",
+    "\n",
+    "## Stemming and Lemmatization\n",
+    "\n",
+    "Stemming and lemmatization are fundamental concepts in Natural Language Processing (NLP) used to reduce words to their base or root form.\n",
+    "\n",
+    "- **Stemming**: This technique uses fixed rules to strip affixes from words, resulting in a base form that may not always be a valid word. For example, \"running\" becomes \"run\" and \"flies\" becomes \"fli\".\n",
+    "- **Lemmatization**: Unlike stemming, lemmatization leverages knowledge of a language, such as vocabulary and morphological analysis, to derive the base or dictionary form of a word. For instance, \"running\" becomes \"run\" and \"flies\" becomes \"fly\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b0761fea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nltk\n",
+    "import spacy\n",
+    "from nltk.stem import PorterStemmer\n",
+    "\n",
+    "stemmer = PorterStemmer()\n",
+    "spacy_nlp = spacy.load(\"en_core_web_sm\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1405c8df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "safety_reports = [\n",
+    "    \"Wear appropriate personal protective equipment\",\n",
+    "    \"Organize periodic safety drills\",\n",
+    "    \"Examine machinery for potential hazards\",\n",
+    "    \"Deliver safety training to employees\",\n",
+    "    \"Keep emergency exits unobstructed\",\n",
+    "    \"Log and report workplace incidents\",\n",
+    "    \"Adhere to chemical handling guidelines\",\n",
+    "    \"Assess air quality in confined spaces\",\n",
+    "    \"Mark hazardous materials clearly\",\n",
+    "    \"Perform regular risk evaluations\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "795098b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wear --> wear\n",
+      "appropriate --> appropri\n",
+      "personal --> person\n",
+      "protective --> protect\n",
+      "equipment --> equip\n",
+      "Organize --> organ\n",
+      "periodic --> period\n",
+      "safety --> safeti\n",
+      "drills --> drill\n",
+      "Examine --> examin\n",
+      "machinery --> machineri\n",
+      "for --> for\n",
+      "potential --> potenti\n",
+      "hazards --> hazard\n",
+      "Deliver --> deliv\n",
+      "safety --> safeti\n",
+      "training --> train\n",
+      "to --> to\n",
+      "employees --> employe\n",
+      "Keep --> keep\n",
+      "emergency --> emerg\n",
+      "exits --> exit\n",
+      "unobstructed --> unobstruct\n",
+      "Log --> log\n",
+      "and --> and\n",
+      "report --> report\n",
+      "workplace --> workplac\n",
+      "incidents --> incid\n",
+      "Adhere --> adher\n",
+      "to --> to\n",
+      "chemical --> chemic\n",
+      "handling --> handl\n",
+      "guidelines --> guidelin\n",
+      "Assess --> assess\n",
+      "air --> air\n",
+      "quality --> qualiti\n",
+      "in --> in\n",
+      "confined --> confin\n",
+      "spaces --> space\n",
+      "Mark --> mark\n",
+      "hazardous --> hazard\n",
+      "materials --> materi\n",
+      "clearly --> clearli\n",
+      "Perform --> perform\n",
+      "regular --> regular\n",
+      "risk --> risk\n",
+      "evaluations --> evalu\n"
+     ]
+    }
+   ],
+   "source": [
+    "for report in safety_reports:\n",
+    "    for word in report.split():\n",
+    "        print(f\"{word} --> {stemmer.stem(word)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "959d47d3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wear --> wear\n",
+      "appropriate --> appropriate\n",
+      "personal --> personal\n",
+      "protective --> protective\n",
+      "equipment --> equipment\n",
+      "Organize --> organize\n",
+      "periodic --> periodic\n",
+      "safety --> safety\n",
+      "drills --> drill\n",
+      "Examine --> examine\n",
+      "machinery --> machinery\n",
+      "for --> for\n",
+      "potential --> potential\n",
+      "hazards --> hazard\n",
+      "Deliver --> deliver\n",
+      "safety --> safety\n",
+      "training --> training\n",
+      "to --> to\n",
+      "employees --> employee\n",
+      "Keep --> keep\n",
+      "emergency --> emergency\n",
+      "exits --> exit\n",
+      "unobstructed --> unobstructed\n",
+      "Log --> log\n",
+      "and --> and\n",
+      "report --> report\n",
+      "workplace --> workplace\n",
+      "incidents --> incident\n",
+      "Adhere --> adhere\n",
+      "to --> to\n",
+      "chemical --> chemical\n",
+      "handling --> handling\n",
+      "guidelines --> guideline\n",
+      "Assess --> Assess\n",
+      "air --> air\n",
+      "quality --> quality\n",
+      "in --> in\n",
+      "confined --> confine\n",
+      "spaces --> space\n",
+      "Mark --> Mark\n",
+      "hazardous --> hazardous\n",
+      "materials --> material\n",
+      "clearly --> clearly\n",
+      "Perform --> perform\n",
+      "regular --> regular\n",
+      "risk --> risk\n",
+      "evaluations --> evaluation\n"
+     ]
+    }
+   ],
+   "source": [
+    "# use lemmatization in spacy\n",
+    "nlp = spacy.load(\"en_core_web_sm\")\n",
+    "for report in safety_reports:\n",
+    "    doc = nlp(report)\n",
+    "    for token in doc:\n",
+    "        print(f\"{token.text} --> {token.lemma_}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ This repository contains my studies and experiments in Natural Language Processi
 
 - **01_basic_nlp_course/**
 	- Notebooks and materials for a basic NLP course, including:
+
 		- `01_regular_expressions.ipynb`: Introduction to regular expressions in NLP.
+		- `02_nltk_vs_spacy.ipynb`: Comparison of NLTK and spaCy for NLP tasks, including tokenization, lemmatization, POS tagging, and named entity recognition.
+		- `03_language_processing_pipeline.ipynb`: Building and visualizing language processing pipelines in spaCy, with practical examples and exercises.
+		- `04_stemming_lemmatization.ipynb`: Introduction to stemming and lemmatization techniques in NLP, with code examples and practical exercises.
 
 ## Other Files
 


### PR DESCRIPTION
## Changelog for Commit a34f411

### ✨ Feature: Adds Class 04 — Stemming and Lemmatization

#### Major Updates

- **New Jupyter Notebook Added**
  - Created `01_basic_nlp_course/04_stemming_lemmatization.ipynb` (211 lines).
  - The notebook covers:
    - Theoretical introduction to stemming and lemmatization in NLP.
    - Practical code examples using NLTK's PorterStemmer and spaCy's lemmatizer.
    - Application to safety report texts, showing word transformations for both techniques.
    - Markdown explanations and step-by-step outputs for educational clarity.

- **README Update**
  - Added `04_stemming_lemmatization.ipynb` to the list of notebooks in the `01_basic_nlp_course` section.
  - Provided a brief description for each notebook, ensuring the README accurately reflects all course content.

---

**Summary:**  
This commit introduces a new class notebook on stemming and lemmatization, expands the educational material, and updates the README to document all current NLP course